### PR TITLE
fixed command in readme

### DIFF
--- a/oracle-8/README.md
+++ b/oracle-8/README.md
@@ -12,7 +12,7 @@ The `Dockerfile` assumes you have the policy files available:
 
 * Download `jce_policy-8.zip` [from Oracle](http://www.oracle.com/technetwork/java/javase/downloads/jce8-download-2133166.html).
 You will need to accept their license agreement to do this.
-* `gunzip jce_policy-8.zip` will generate the `UnlimitedJCEPolicyJDK8`
+* `unzip jce_policy-8.zip` will generate the `UnlimitedJCEPolicyJDK8`
 directory assumed by the `Dockerfile`.
 
 Run `./build` to build the image.


### PR DESCRIPTION
gunzip doesn't work with *.zip, but unzip does

``` sh
$ gunzip jce_policy-8.zip                                                       
gzip: jce_policy-8.zip: unknown suffix -- ignored

$ gunzip --version
gunzip (gzip) 1.6
```

``` sh
$ unzip jce_policy-8.zip 
Archive:  jce_policy-8.zip
   creating: UnlimitedJCEPolicyJDK8/
  inflating: UnlimitedJCEPolicyJDK8/local_policy.jar  
  inflating: UnlimitedJCEPolicyJDK8/README.txt  
  inflating: UnlimitedJCEPolicyJDK8/US_export_policy.jar
```
