### PR TITLE
Run 'apt get update' before 'apt-get install software-properties-common'

### DIFF
--- a/oracle-8/Dockerfile
+++ b/oracle-8/Dockerfile
@@ -10,9 +10,9 @@ MAINTAINER Ian Young <ian@iay.org.uk>
 #
 # The Oracle license prompt is auto-accepted.
 #
-RUN apt-get install -y software-properties-common && \
+RUN apt-get update && \
+    apt-get install -y software-properties-common && \
     add-apt-repository -y ppa:webupd8team/java && \
-    apt-get update && \
     echo oracle-java8-installer shared/accepted-oracle-license-v1-1 select true | debconf-set-selections && \
     apt-get install -y oracle-java8-installer && \
     rm -rf /var/lib/apt/lists/* && \


### PR DESCRIPTION
Fix "E: Unable to locate package software-properties-common" by running 'apt-get update' first.
